### PR TITLE
Made VortoValue class public so that it could be used in a custom TypeConverter class

### DIFF
--- a/Src/Our.Umbraco.Vorto/Models/VortoValue.cs
+++ b/Src/Our.Umbraco.Vorto/Models/VortoValue.cs
@@ -4,8 +4,12 @@ using Newtonsoft.Json;
 
 namespace Our.Umbraco.Vorto.Models
 {
-	internal class VortoValue
+	public class VortoValue
 	{
+        internal VortoValue()
+        {
+        }
+
 		[JsonProperty("values")]
 		public IDictionary<string, object> Values { get; set; }
 


### PR DESCRIPTION
For complex Type Converters where you need to compare the object value to a VortoValue.  Kept constructor internal.